### PR TITLE
Add log out option to reconnecting banner

### DIFF
--- a/src/components/ConnectionError.js
+++ b/src/components/ConnectionError.js
@@ -1,25 +1,55 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import history from '../app/history'
+import { createFlashMessage } from '../actions/flashMessages'
+import { logOut } from '../actions/currentUser'
 import { isConnected } from '../reducers/socket'
+import { isClientType } from '../reducers/client'
+import { Button } from 'antd'
 
-const ConnectionError = ({ connected }) => {
+const ConnectionError = ({ connected, flashMessage, isPortable, onLogOut }) => {
   if (connected) {
     return null
+  }
+
+  const handleReset = (event) => {
+    if (event) {
+      event.preventDefault()
+    }
+
+    onLogOut()
+    flashMessage('Successfully logged out', 'success')
+    history.push('/')
   }
 
   return (
     <div className='chat-overlay'>
       <div className='connection-error'>
-        Reconnecting...
+        <p>
+          Reconnecting...
+          { !isPortable &&
+            <span>
+              or <Button onClick={handleReset}>Log Out</Button>
+            </span>
+          }
+        </p>
       </div>
     </div>
   )
 }
 
 const mapStateToProps = (state) => ({
-  connected: isConnected(state)
+  connected: isConnected(state),
+  isPortable: isClientType(state, 'portable')
+})
+
+const mapDispatchToProps = (dispatch) => ({
+  flashMessage: (title, type, description) => (
+    dispatch(createFlashMessage(title, type, description))
+  ),
+  onLogOut: () => dispatch(logOut())
 })
 
 ConnectionError.displayName = 'ConnectionError'
 
-export default connect(mapStateToProps)(ConnectionError)
+export default connect(mapStateToProps, mapDispatchToProps)(ConnectionError)

--- a/src/pages/User/_Logout.js
+++ b/src/pages/User/_Logout.js
@@ -3,13 +3,11 @@ import { connect } from 'react-redux'
 import history from '../../app/history'
 import { createFlashMessage } from '../../actions/flashMessages'
 import { logOut } from '../../actions/currentUser'
-import { socketClose } from '../../actions/socket'
 import { Button, Icon } from 'antd'
 
-export const Logout = ({ flashMessage, onCloseSocket, onLogOut }) => {
+export const Logout = ({ flashMessage, onLogOut }) => {
   const onClick = () => {
     onLogOut()
-    onCloseSocket()
     flashMessage('Successfully logged out', 'success')
     history.push('/')
   }
@@ -27,7 +25,6 @@ const mapDispatchToProps = (dispatch) => ({
   flashMessage: (title, type, description) => (
     dispatch(createFlashMessage(title, type, description))
   ),
-  onCloseSocket: () => dispatch(socketClose()),
   onLogOut: () => dispatch(logOut())
 })
 

--- a/src/reducers/channels.js
+++ b/src/reducers/channels.js
@@ -10,6 +10,7 @@ export const channelsReducer = (state = initialState, action) => {
     case 'CHANNEL_LEAVE':
       delete state[action.key]
       return state
+    case 'CURRENT_USER_LOGOUT':
     case 'SOCKET_CLOSE':
       return initialState
     default:

--- a/src/reducers/client.js
+++ b/src/reducers/client.js
@@ -15,5 +15,6 @@ const clientReducer = (state = initialState, action) => {
 }
 
 export const getClientType = (state) => (state.client || {}).clientType
+export const isClientType = (state, key) => getClientType(state) === key
 
 export default clientReducer

--- a/src/reducers/socket.js
+++ b/src/reducers/socket.js
@@ -10,6 +10,7 @@ const socketReducer = (state = initialState, action) => {
       return {...state, connection: action.connection}
     case 'SOCKET_OPEN':
       return {...state, connected: true}
+    case 'CURRENT_USER_LOGOUT':
     case 'SOCKET_CLOSE':
       return initialState
     default:

--- a/src/static/common.css
+++ b/src/static/common.css
@@ -97,8 +97,9 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    height: 10%;
-    max-height: 100px; }
+    min-height: 2em;
+    height: 20%;
+    max-height: 80px; }
   #chat-root #login-container {
     position: relative;
     height: 100vh;

--- a/src/static/common.scss
+++ b/src/static/common.scss
@@ -141,8 +141,9 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    height: 10%;
-    max-height: 100px;
+    min-height: 2em;
+    height: 20%;
+    max-height: 80px;
   }
 
   #login-container {


### PR DESCRIPTION
### About

Adds a `log out` button to the reconnecting banner. Useful for resetting application state once localstorage gets in a bad state.

### Scope

Visible in desktop and web clients. Hidden in portable.

### Screenshots

![screen shot 2017-10-09 at 4 31 15 pm](https://user-images.githubusercontent.com/461172/31357331-4e5ed852-ad0f-11e7-9b80-4b4a50c027aa.png)

