### PR TITLE
Make client-server connectivity more reliable and self-healing

### DIFF
--- a/src/actions/rooms.js
+++ b/src/actions/rooms.js
@@ -2,7 +2,7 @@ import { reverse } from 'lodash'
 import { joinChannel } from './channels'
 import { addMessage, removeMessage, replaceMessage, replaceMessages } from './roomMessages'
 import { addRoomSubscription, replaceRoomSubscriptions } from './roomSubscriptions'
-import { addUserSubscription, replaceUserSubscriptions } from './userSubscriptions'
+import { addUserSubscription, joinAllRoomChannels, replaceUserSubscriptions } from './userSubscriptions'
 import { getRoomsChannel } from '../reducers/rooms'
 import { camelize } from '../helpers/data'
 
@@ -25,10 +25,12 @@ export const joinRoomsChannel = (onSuccess, onError) => (dispatch, getState) => 
   const channelCallbacks = (channel) => {
     channel.on('user:subscriptions', (data) => {
       dispatch(replaceUserSubscriptions(camelize(data.subscriptions)))
+      dispatch(joinAllRoomChannels())
     })
 
     channel.on('user:subscription:created', (data) => {
       dispatch(addUserSubscription(camelize(data)))
+      dispatch(joinAllRoomChannels())
     })
 
     return channel
@@ -50,6 +52,7 @@ export const joinRoomChannel = (slug, onSuccess, onError) => (dispatch, getState
 
     channel.on('user:subscription:created', (data) => {
       dispatch(addUserSubscription(camelize(data)))
+      dispatch(joinAllRoomChannels())
     })
 
     channel.on('messages:list', (data) => {

--- a/src/actions/userSubscriptions.js
+++ b/src/actions/userSubscriptions.js
@@ -20,7 +20,6 @@ export const replaceUserSubscriptions = (subscriptions) => ({
 })
 
 export const joinAllRoomChannels = () => (dispatch, getState) => {
-  // Note: joinRoomChannel will noop if channel is already connected.
   const rooms = getRooms(getState())
   const join = (room) => dispatch(joinRoomChannel(room.slug))
 

--- a/src/actions/userSubscriptions.js
+++ b/src/actions/userSubscriptions.js
@@ -1,4 +1,7 @@
+import { map } from 'lodash'
+import { joinRoomChannel } from './rooms'
 import { getRoomChannel } from '../reducers/rooms'
+import { getRooms } from '../reducers/userSubscriptions'
 
 export const createSubscription = (slug) => (dispatch, getState) => {
   const channel = getRoomChannel(getState(), slug)
@@ -15,3 +18,11 @@ export const replaceUserSubscriptions = (subscriptions) => ({
   type: 'REPLACE_USER_SUBSCRIPTIONS',
   subscriptions: subscriptions
 })
+
+export const joinAllRoomChannels = () => (dispatch, getState) => {
+  // Note: joinRoomChannel will noop if channel is already connected.
+  const rooms = getRooms(getState())
+  const join = (room) => dispatch(joinRoomChannel(room.slug))
+
+  return map(rooms, join)
+}

--- a/src/components/ConnectionError.js
+++ b/src/components/ConnectionError.js
@@ -3,12 +3,12 @@ import { connect } from 'react-redux'
 import history from '../app/history'
 import { createFlashMessage } from '../actions/flashMessages'
 import { logOut } from '../actions/currentUser'
-import { isConnected } from '../reducers/socket'
+import { getIsConnected } from '../reducers/socket'
 import { isClientType } from '../reducers/client'
 import { Button } from 'antd'
 
-const ConnectionError = ({ connected, flashMessage, isPortable, onLogOut }) => {
-  if (connected) {
+const ConnectionError = ({ flashMessage, isConnected, isPortable, onLogOut }) => {
+  if (isConnected) {
     return null
   }
 
@@ -39,7 +39,7 @@ const ConnectionError = ({ connected, flashMessage, isPortable, onLogOut }) => {
 }
 
 const mapStateToProps = (state) => ({
-  connected: isConnected(state),
+  isConnected: getIsConnected(state),
   isPortable: isClientType(state, 'portable')
 })
 

--- a/src/pages/Layout/_Page.js
+++ b/src/pages/Layout/_Page.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { fetchSocket } from '../../actions/socket'
-import { getIsLoggedIn } from '../../reducers/currentUser'
 import { joinRoomsChannel } from '../../actions/rooms'
 import { joinSupportRoomsChannel } from '../../actions/supportRooms'
 import { joinUsersChannel } from '../../actions/users'
+import { getIsLoggedIn } from '../../reducers/currentUser'
+import { getIsConnected } from '../../reducers/socket'
 import parallel from '../../helpers/parallel'
 import { Layout } from 'antd'
 
@@ -16,7 +17,13 @@ class Page extends Component {
   }
 
   componentWillReceiveProps (next) {
+    const isReconnect = (this.props.isConnected === false && next.isConnected === true)
+
     if (!this.props.isLoggedIn && next.isLoggedIn) {
+      this.props.handleLogin()
+    }
+
+    if (next.isLoggedIn && isReconnect) {
       this.props.handleLogin()
     }
   }
@@ -33,6 +40,7 @@ class Page extends Component {
 }
 
 const mapStateToProps = (state) => ({
+  isConnected: getIsConnected(state),
   isLoggedIn: getIsLoggedIn(state)
 })
 

--- a/src/pages/Layout/_Page.js
+++ b/src/pages/Layout/_Page.js
@@ -15,6 +15,12 @@ class Page extends Component {
     }
   }
 
+  componentWillReceiveProps (next) {
+    if (!this.props.isLoggedIn && next.isLoggedIn) {
+      this.props.handleLogin()
+    }
+  }
+
   render () {
     const { children } = this.props
 

--- a/src/pages/Login/Callback.js
+++ b/src/pages/Login/Callback.js
@@ -4,7 +4,6 @@ import { compose, graphql } from 'react-apollo'
 import { logInWithProvider } from '../../api/session'
 import history from '../../app/history'
 import { logIn as logInCurrentUser } from '../../actions/currentUser'
-import { fetchSocket } from '../../actions/socket'
 import { getIsLoggedIn } from '../../reducers/currentUser'
 import { queryString } from '../../helpers/paths'
 import Page from '../../components/Page'
@@ -55,7 +54,6 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => ({
   logInToClient: (data) => {
     dispatch(logInCurrentUser(data))
-    dispatch(fetchSocket())
   }
 })
 

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { logIn as logInCurrentUser } from '../../actions/currentUser'
-import { fetchSocket } from '../../actions/socket'
 import { getIsLoggedIn } from '../../reducers/currentUser'
 import history from '../../app/history'
 import ApolloClient from '../../components/ApolloClient'
@@ -71,7 +70,6 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => ({
   logInToClient: (data) => {
     dispatch(logInCurrentUser(data))
-    dispatch(fetchSocket())
   }
 })
 

--- a/src/pages/Portable/index.js
+++ b/src/pages/Portable/index.js
@@ -5,6 +5,7 @@ import { joinRoomChannel, joinRoomsChannel } from '../../actions/rooms'
 import { joinUsersChannel } from '../../actions/users'
 import { fetchSocket, socketClose } from '../../actions/socket'
 import { getActiveRoom, getHasRecentActivity, getIsOpen } from '../../reducers/portable'
+import { getIsConnected } from '../../reducers/socket'
 import { shortUuid } from '../../helpers/uuid'
 import ConnectionError from '../../components/ConnectionError'
 import MessagesList from '../Messages/_List'
@@ -64,6 +65,14 @@ class Portable extends Component {
     this.props.onLoad(room, isActive)
   }
 
+  componentWillReceiveProps (next) {
+    const isReconnect = (this.props.isConnected === false && next.isConnected === true)
+
+    if (isReconnect) {
+      this.props.onLoad(next.room, next.isActive)
+    }
+  }
+
   render () {
     const { isActive, isClosed, onClose, onNew, onOpen, room } = this.props
     const classnames = 'chat-portable ' + (isClosed ? 'closed' : 'open')
@@ -97,6 +106,7 @@ const mapStateToProps = (state) => {
   return {
     isActive: isActive,
     isClosed: !getIsOpen(state),
+    isConnected: getIsConnected(state),
     room: isActive ? activeRoom : newRoom
   }
 }

--- a/src/pages/User/_Logout.js
+++ b/src/pages/User/_Logout.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import history from '../../app/history'
 import { createFlashMessage } from '../../actions/flashMessages'
 import { logOut } from '../../actions/currentUser'
+import { socketClose } from '../../actions/socket'
 import { Button, Icon } from 'antd'
 
 export const Logout = ({ flashMessage, onLogOut }) => {
@@ -25,7 +26,10 @@ const mapDispatchToProps = (dispatch) => ({
   flashMessage: (title, type, description) => (
     dispatch(createFlashMessage(title, type, description))
   ),
-  onLogOut: () => dispatch(logOut())
+  onLogOut: () => {
+    dispatch(socketClose())
+    dispatch(logOut())
+  }
 })
 
 export default connect(undefined, mapDispatchToProps)(Logout)

--- a/src/reducers/channels.js
+++ b/src/reducers/channels.js
@@ -1,3 +1,5 @@
+import { map, omit } from 'lodash'
+
 const initialState = {}
 
 export const channelsReducer = (state = initialState, action) => {
@@ -8,10 +10,13 @@ export const channelsReducer = (state = initialState, action) => {
         [action.key]: action.channel
       }
     case 'CHANNEL_LEAVE':
-      delete state[action.key]
-      return state
+      state[action.key].leave()
+
+      return omit(state, action.key)
     case 'CURRENT_USER_LOGOUT':
     case 'SOCKET_CLOSE':
+      map(state, (channel) => channel.leave())
+
       return initialState
     default:
       return state

--- a/src/reducers/socket.js
+++ b/src/reducers/socket.js
@@ -20,7 +20,7 @@ const socketReducer = (state = initialState, action) => {
 
 export const getSocket = (state) => state.socket
 export const getSocketConnection = (state) => state.socket.connection
-export const isConnected = (state) => state.socket.connected
+export const getIsConnected = (state) => state.socket.connected
 export const withSocketConnection = (getState, callback, attempt = 0, throwOnError = false) => {
   const interval = 25
   const max = Math.ceil(5000 / interval)


### PR DESCRIPTION
Updates socket and channel behavior to:
- DRY up socket connection calls
- Send a `leave` message to each channel on log out
- Close the socket connection on log out
- Connect to every room channel in the user's subscriptions
- Detect when a socket has reconnected
- Reconnect to every room channel on socket reconnect

Combined these changes make connectivity more reliable and self-healing.